### PR TITLE
AWS Big Data Blog Post- Zeppelin on EC2 As Yarn Client Posted

### DIFF
--- a/aws-blog-zeppelin-yarn-on-ec2/README.md
+++ b/aws-blog-zeppelin-yarn-on-ec2/README.md
@@ -1,0 +1,8 @@
+# Setting up Apache Zeppelin on EC2 as a YARN client#
+This is the code repository for samples used the AWS Big Data blog Taking Flight with Apache Zeppelin on EC2 as an EMR Yarn Client
+
+###Overview of Example###
+
+This repository contains a CloudFormation script that bootstraps an EC2 instance with Apache Zeppelin, configures the instance as a YARN client of an EMR cluster, and configures Zeppelin to store notebooks in S3. Please see the blog post of the same name for configuration instructions.
+
+**Important:** These resources will incur charges on your AWS bill. It is your responsbility to delete these resources.

--- a/aws-blog-zeppelin-yarn-on-ec2/conf/slaves
+++ b/aws-blog-zeppelin-yarn-on-ec2/conf/slaves
@@ -1,0 +1,2 @@
+# A Spark Worker will be started on each of the machines listed below.
+localhost

--- a/aws-blog-zeppelin-yarn-on-ec2/conf/spark-env.sh
+++ b/aws-blog-zeppelin-yarn-on-ec2/conf/spark-env.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# This file is sourced when running various Spark programs.
+# Copy it as spark-env.sh and edit that to configure Spark for your site.
+
+# Options read when launching programs locally with
+# ./bin/run-example or ./bin/spark-submit
+# - HADOOP_CONF_DIR, to point Spark towards Hadoop configuration files
+# - SPARK_LOCAL_IP, to set the IP address Spark binds to on this node
+# - SPARK_PUBLIC_DNS, to set the public dns name of the driver program
+# - SPARK_CLASSPATH, default classpath entries to append
+
+# Options read by executors and drivers running inside the cluster
+# - SPARK_LOCAL_IP, to set the IP address Spark binds to on this node
+# - SPARK_PUBLIC_DNS, to set the public DNS name of the driver program
+# - SPARK_CLASSPATH, default classpath entries to append
+# - SPARK_LOCAL_DIRS, storage directories to use on this node for shuffle and RDD data
+# - MESOS_NATIVE_JAVA_LIBRARY, to point to your libmesos.so if you use Mesos
+
+# Options read in YARN client mode
+export JAVA_HOME=/etc/alternatives/java_sdk_openjdk
+export HADOOP_CONF_DIR=/home/ec2-user/hadoopconf
+# - SPARK_EXECUTOR_INSTANCES, Number of workers to start (Default: 2)
+# - SPARK_EXECUTOR_CORES, Number of cores for the workers (Default: 1).
+# - SPARK_EXECUTOR_MEMORY, Memory per Worker (e.g. 1000M, 2G) (Default: 1G)
+# - SPARK_DRIVER_MEMORY, Memory for Master (e.g. 1000M, 2G) (Default: 1G)
+# - SPARK_YARN_APP_NAME, The name of your application (Default: Spark)
+# - SPARK_YARN_QUEUE, The hadoop queue to use for allocation requests (Default: ‘default’)
+# - SPARK_YARN_DIST_FILES, Comma separated list of files to be distributed with the job.
+# - SPARK_YARN_DIST_ARCHIVES, Comma separated list of archives to be distributed with the job.
+
+# Options for the daemons used in the standalone deploy mode
+# - SPARK_MASTER_IP, to bind the master to a different IP address or hostname
+# - SPARK_MASTER_PORT / SPARK_MASTER_WEBUI_PORT, to use non-default ports for the master
+# - SPARK_MASTER_OPTS, to set config properties only for the master (e.g. "-Dx=y")
+# - SPARK_WORKER_CORES, to set the number of cores to use on this machine
+# - SPARK_WORKER_MEMORY, to set how much total memory workers have to give executors (e.g. 1000m, 2g)
+# - SPARK_WORKER_PORT / SPARK_WORKER_WEBUI_PORT, to use non-default ports for the worker
+# - SPARK_WORKER_INSTANCES, to set the number of worker processes per node
+# - SPARK_WORKER_DIR, to set the working directory of worker processes
+# - SPARK_WORKER_OPTS, to set config properties only for the worker (e.g. "-Dx=y")
+# - SPARK_DAEMON_MEMORY, to allocate to the master, worker and history server themselves (default: 1g).
+# - SPARK_HISTORY_OPTS, to set config properties only for the history server (e.g. "-Dx=y")
+# - SPARK_SHUFFLE_OPTS, to set config properties only for the external shuffle service (e.g. "-Dx=y")
+# - SPARK_DAEMON_JAVA_OPTS, to set config properties for all daemons (e.g. "-Dx=y")
+# - SPARK_PUBLIC_DNS, to set the public dns name of the master or workers
+
+# Generic options for the daemons used in the standalone deploy mode
+# - SPARK_CONF_DIR      Alternate conf dir. (Default: ${SPARK_HOME}/conf)
+# - SPARK_LOG_DIR       Where log files are stored.  (Default: ${SPARK_HOME}/logs)
+# - SPARK_PID_DIR       Where the pid file is stored. (Default: /tmp)
+# - SPARK_IDENT_STRING  A string representing this instance of spark. (Default: $USER)
+# - SPARK_NICENESS      The scheduling priority for daemons. (Default: 0)

--- a/aws-blog-zeppelin-yarn-on-ec2/conf/zeppelin-env.sh
+++ b/aws-blog-zeppelin-yarn-on-ec2/conf/zeppelin-env.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export JAVA_HOME=/etc/alternatives/java_sdk_openjdk
+export MASTER=yarn-client                 	
+export HADOOP_CONF_DIR=/home/ec2-user/hadoopconf
+# export ZEPPELIN_JAVA_OPTS      		# Additional jvm options. for example, export ZEPPELIN_JAVA_OPTS="-Dspark.executor.memory=8g -Dspark.cores.max=16"
+# export ZEPPELIN_MEM            		# Zeppelin jvm mem options Default -Xmx1024m -XX:MaxPermSize=512m
+# export ZEPPELIN_INTP_MEM       		# zeppelin interpreter process jvm mem options. Default = ZEPPELIN_MEM
+# export ZEPPELIN_INTP_JAVA_OPTS 		# zeppelin interpreter process jvm options. Default = ZEPPELIN_JAVA_OPTS
+
+# export ZEPPELIN_LOG_DIR        		# Where log files are stored.  PWD by default.
+# export ZEPPELIN_PID_DIR        		# The pid files are stored. /tmp by default.
+# export ZEPPELIN_WAR_TEMPDIR    		# The location of jetty temporary directory.
+# export ZEPPELIN_NOTEBOOK_DIR   		# Where notebook saved
+# export ZEPPELIN_NOTEBOOK_HOMESCREEN		# Id of notebook to be displayed in homescreen. ex) 2A94M5J1Z
+# export ZEPPELIN_NOTEBOOK_HOMESCREEN_HIDE	# hide homescreen notebook from list when this value set to "true". default "false"
+export ZEPPELIN_NOTEBOOK_STORAGE=org.apache.zeppelin.notebook.repo.S3NotebookRepo
+export ZEPPELIN_NOTEBOOK_S3_BUCKET=    
+export ZEPPELIN_NOTEBOOK_S3_USER=      
+# export ZEPPELIN_IDENT_STRING   		# A string representing this instance of zeppelin. $USER by default.
+# export ZEPPELIN_NICENESS       		# The scheduling priority for daemons. Defaults to 0.
+
+
+#### Spark interpreter configuration ####
+
+## Use provided spark installation ##
+## defining SPARK_HOME makes Zeppelin run spark interpreter process using spark-submit
+##
+# export SPARK_HOME                             # (required) When it is defined, load it instead of Zeppelin embedded Spark libraries
+# export SPARK_SUBMIT_OPTIONS                   # (optional) extra options to pass to spark submit. eg) "--driver-memory 512M --executor-memory 1G".
+
+## Use embedded spark binaries ##
+## without SPARK_HOME defined, Zeppelin still able to run spark interpreter process using embedded spark binaries.
+## however, it is not encouraged when you can define SPARK_HOME
+##
+# Options read in YARN client mode
+# export HADOOP_CONF_DIR         		# yarn-site.xml is located in configuration directory in HADOOP_CONF_DIR.
+# Pyspark (supported with Spark 1.2.1 and above)
+# To configure pyspark, you need to set spark distribution's path to 'spark.home' property in Interpreter setting screen in Zeppelin GUI
+# export PYSPARK_PYTHON          		# path to the python command. must be the same path on the driver(Zeppelin) and all workers.
+# export PYTHONPATH  
+
+## Spark interpreter options ##
+##
+# export ZEPPELIN_SPARK_USEHIVECONTEXT  # Use HiveContext instead of SQLContext if set true. true by default.
+# export ZEPPELIN_SPARK_CONCURRENTSQL   # Execute multiple SQL concurrently if set true. false by default.
+# export ZEPPELIN_SPARK_MAXRESULT       # Max number of SparkSQL result to display. 1000 by default.
+

--- a/aws-blog-zeppelin-yarn-on-ec2/conf/zeppelin-site.xml
+++ b/aws-blog-zeppelin-yarn-on-ec2/conf/zeppelin-site.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+
+<property>
+  <name>zeppelin.server.addr</name>
+  <value>0.0.0.0</value>
+  <description>Server address</description>
+</property>
+
+<property>
+  <name>zeppelin.server.port</name>
+  <value>8080</value>
+  <description>Server port.</description>
+</property>
+
+<property>
+  <name>zeppelin.server.context.path</name>
+  <value>/</value>
+  <description>Context Path of the Web Application</description>
+</property>
+
+<property>
+  <name>zeppelin.war.tempdir</name>
+  <value>webapps</value>
+  <description>Location of jetty temporary directory</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.dir</name>
+  <value>notebook</value>
+  <description>path or URI for notebook persist</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.homescreen</name>
+  <value></value>
+  <description>id of notebook to be displayed in homescreen. ex) 2A94M5J1Z Empty value displays default home screen</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.homescreen.hide</name>
+  <value>false</value>
+  <description>hide homescreen notebook from list when this value set to true</description>
+</property>
+
+
+<!-- If used S3 to storage the notebooks, it is necessary the following folder structure bucketname/username/notebook/ -->
+
+<property>
+  <name>zeppelin.notebook.s3.user</name>
+  <value>user</value>
+  <description>user name for s3 folder structure</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.s3.bucket</name>
+  <value>zeppelin</value>
+  <description>bucket name for notebook storage</description>
+</property>
+
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.S3NotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
+</property>
+
+
+<!-- For versioning your local norebook storage using Git repository
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.GitNotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
+</property>
+-->
+<!--
+<property>
+  <name>zeppelin.notebook.storage</name>
+  <value>org.apache.zeppelin.notebook.repo.VFSNotebookRepo</value>
+  <description>notebook persistence layer implementation</description>
+</property>
+-->
+<property>
+  <name>zeppelin.interpreter.dir</name>
+  <value>interpreter</value>
+  <description>Interpreter implementation base directory</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreters</name>
+  <value>org.apache.zeppelin.spark.SparkInterpreter,org.apache.zeppelin.spark.PySparkInterpreter,org.apache.zeppelin.spark.SparkSqlInterpreter,org.apache.zeppelin.spark.DepInterpreter,org.apache.zeppelin.markdown.Markdown,org.apache.zeppelin.angular.AngularInterpreter,org.apache.zeppelin.shell.ShellInterpreter,org.apache.zeppelin.hive.HiveInterpreter,org.apache.zeppelin.tajo.TajoInterpreter,org.apache.zeppelin.flink.FlinkInterpreter,org.apache.zeppelin.lens.LensInterpreter,org.apache.zeppelin.ignite.IgniteInterpreter,org.apache.zeppelin.ignite.IgniteSqlInterpreter,org.apache.zeppelin.cassandra.CassandraInterpreter,org.apache.zeppelin.geode.GeodeOqlInterpreter,org.apache.zeppelin.postgresql.PostgreSqlInterpreter,org.apache.zeppelin.phoenix.PhoenixInterpreter,org.apache.zeppelin.kylin.KylinInterpreter</value>
+  <description>Comma separated interpreter configurations. First interpreter become a default</description>
+</property>
+
+<property>
+  <name>zeppelin.interpreter.connect.timeout</name>
+  <value>30000</value>
+  <description>Interpreter process connect timeout in msec.</description>
+</property>
+
+
+<property>
+  <name>zeppelin.ssl</name>
+  <value>false</value>
+  <description>Should SSL be used by the servers?</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.client.auth</name>
+  <value>false</value>
+  <description>Should client authentication be used for SSL connections?</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.keystore.path</name>
+  <value>keystore</value>
+  <description>Path to keystore relative to Zeppelin configuration directory</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.keystore.type</name>
+  <value>JKS</value>
+  <description>The format of the given keystore (e.g. JKS or PKCS12)</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.keystore.password</name>
+  <value>change me</value>
+  <description>Keystore password. Can be obfuscated by the Jetty Password tool</description>
+</property>
+
+<!--
+<property>
+  <name>zeppelin.ssl.key.manager.password</name>
+  <value>change me</value>
+  <description>Key Manager password. Defaults to keystore password. Can be obfuscated.</description>
+</property>
+-->
+
+<property>
+  <name>zeppelin.ssl.truststore.path</name>
+  <value>truststore</value>
+  <description>Path to truststore relative to Zeppelin configuration directory. Defaults to the keystore path</description>
+</property>
+
+<property>
+  <name>zeppelin.ssl.truststore.type</name>
+  <value>JKS</value>
+  <description>The format of the given truststore (e.g. JKS or PKCS12). Defaults to the same type as the keystore type</description>
+</property>
+
+<!--
+<property>
+  <name>zeppelin.ssl.truststore.password</name>
+  <value>change me</value>
+  <description>Truststore password. Can be obfuscated by the Jetty Password tool. Defaults to the keystore password</description>
+</property>
+-->
+
+<property>
+  <name>zeppelin.server.allowed.origins</name>
+  <value>*</value>
+  <description>Allowed sources for REST and WebSocket requests (i.e. http://onehost:8080,http://otherhost.com). If you leave * you are vulnerable to https://issues.apache.org/jira/browse/ZEPPELIN-173</description>
+</property>
+
+</configuration>
+

--- a/aws-blog-zeppelin-yarn-on-ec2/zeppelin-yarn-on-ec2.json
+++ b/aws-blog-zeppelin-yarn-on-ec2/zeppelin-yarn-on-ec2.json
@@ -1,155 +1,343 @@
-<?xml version="1.0"?>
-<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
-<configuration>
-<property><name>yarn.web-proxy.address</name><value>ip-172-31-29-88.us-west-1.compute.internal:20888</value></property>
-<property><name>yarn.resourcemanager.resource-tracker.address</name><value>ip-172-31-29-88.us-west-1.compute.internal:8025</value></property>
-<property><name>yarn.resourcemanager.address</name><value>ip-172-31-29-88.us-west-1.compute.internal:8032</value></property>
-<property><name>yarn.resourcemanager.scheduler.address</name><value>ip-172-31-29-88.us-west-1.compute.internal:8030</value></property>
-<property><name>yarn.nodemanager.aux-services</name>
-<property>
-    <name>yarn.nodemanager.aux-services</name>
-    <value>mapreduce_shuffle,</value>
-  </property>
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  
+  "Description" : "AWS CloudFormation Template: Zeppelin_Yarn_Client: Create a Zeppelin EC2 instance. This template demonstrates using the AWS CloudFormation bootstrap scripts to install Maven, Git, Apache Spark and Apache Zeppelin  at instance launch time. **WARNING** This template creates an Amazon EC2 instance. You will be billed for the AWS resources used if you create a stack from this template.",
+  
+  "Parameters" : {
+      
+    "KeyName": {
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "Can contain only ASCII characters."
+    },    
 
-  <property>
-    <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
-    <value>org.apache.hadoop.mapred.ShuffleHandler</value>
-  </property>
 
-  <property><name>yarn.log-aggregation-enable</name><value>false</value></property>
+    "InstanceType" : {
+      "Description" : "Zeppelin EC2 instance type",
+      "Type" : "String",
+      "Default" : "m3.xlarge",
+      "AllowedValues" : [ "t1.micro", "t2.micro", "t2.small", "t2.medium", "m1.small", "m1.medium", "m1.large", "m1.xlarge", "m2.xlarge", "m2.2xlarge", "m2.4xlarge", "m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge", "c1.medium", "c1.xlarge", "c3.large", "c3.xlarge", "c3.2xlarge", "c3.4xlarge", "c3.8xlarge", "g2.2xlarge", "r3.large", "r3.xlarge", "r3.2xlarge", "r3.4xlarge", "r3.8xlarge", "i2.xlarge", "i2.2xlarge", "i2.4xlarge", "i2.8xlarge", "hi1.4xlarge", "hs1.8xlarge", "cr1.8xlarge", "cc2.8xlarge", "cg1.4xlarge"],
+      "ConstraintDescription" : "Must be a valid EC2 instance type"
+    },
+     "EMRMasterSecurityGroup": {
+      "Description" : "Name of an existing EMR Master Security Group",
+      "Type": "AWS::EC2::SecurityGroup::Id",
+      "ConstraintDescription" : "Can contain only ASCII characters."
+    }, 
+     "EMRSlaveSecurityGroup": {
+      "Description" : "Name of an existing EMR Master Security Group",
+      "Type": "AWS::EC2::SecurityGroup::Id",
+      "ConstraintDescription" : "Can contain only ASCII characters."
+    },
+      "S3HadoopConfFolder": {
+      "Description" : "S3 bucket and folder which contains your hadoop conf directory",
+      "Type": "String",
+      "Default":"mybucket/hadoopconf"
+        },
+    "ZeppelinSubnetId": {
+      "Description" : "Choose a subnet to launch your Zeppelin Instance",
+      "Type": "AWS::EC2::Subnet::Id"
+    },
+    "ZeppelinVPCId": {
+      "Description" : "Choose a VPC to launch your Zeppelin Instance",
+      "Type": "AWS::EC2::VPC::Id"
+    },
+    "SSHLocation" : {
+      "Description" : "The IP address range that can be used to SSH to the EC2 instances",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    } 
+  },
+  
+  "Mappings" : {
+    "AWSInstanceType2Arch" : {
+      "t1.micro"    : { "Arch" : "PV64"   },
+      "t2.micro"    : { "Arch" : "HVM64"  },
+      "t2.small"    : { "Arch" : "HVM64"  },
+      "t2.medium"   : { "Arch" : "HVM64"  },
+      "m1.small"    : { "Arch" : "PV64"   },
+      "m1.medium"   : { "Arch" : "PV64"   },
+      "m1.large"    : { "Arch" : "PV64"   },
+      "m1.xlarge"   : { "Arch" : "PV64"   },
+      "m2.xlarge"   : { "Arch" : "PV64"   },
+      "m2.2xlarge"  : { "Arch" : "PV64"   },
+      "m2.4xlarge"  : { "Arch" : "PV64"   },
+      "m3.medium"   : { "Arch" : "HVM64"  },
+      "m3.large"    : { "Arch" : "HVM64"  },
+      "m3.xlarge"   : { "Arch" : "HVM64"  },
+      "m3.2xlarge"  : { "Arch" : "HVM64"  },
+      "c1.medium"   : { "Arch" : "PV64"   },
+      "c1.xlarge"   : { "Arch" : "PV64"   },
+      "c3.large"    : { "Arch" : "HVM64"  },
+      "c3.xlarge"   : { "Arch" : "HVM64"  },
+      "c3.2xlarge"  : { "Arch" : "HVM64"  },
+      "c3.4xlarge"  : { "Arch" : "HVM64"  },
+      "c3.8xlarge"  : { "Arch" : "HVM64"  },
+      "g2.2xlarge"  : { "Arch" : "HVMG2"  },
+      "r3.large"    : { "Arch" : "HVM64"  },
+      "r3.xlarge"   : { "Arch" : "HVM64"  },
+      "r3.2xlarge"  : { "Arch" : "HVM64"  },
+      "r3.4xlarge"  : { "Arch" : "HVM64"  },
+      "r3.8xlarge"  : { "Arch" : "HVM64"  },
+      "i2.xlarge"   : { "Arch" : "HVM64"  },
+      "i2.2xlarge"  : { "Arch" : "HVM64"  },
+      "i2.4xlarge"  : { "Arch" : "HVM64"  },
+      "i2.8xlarge"  : { "Arch" : "HVM64"  },
+      "hi1.4xlarge" : { "Arch" : "HVM64"  },
+      "hs1.8xlarge" : { "Arch" : "HVM64"  },
+      "cr1.8xlarge" : { "Arch" : "HVM64"  },
+      "cc2.8xlarge" : { "Arch" : "HVM64"  }
+    },
 
-  <property>
-    <name>yarn.dispatcher.exit-on-error</name>
-    <value>true</value>
-  </property>
+    "AWSRegionArch2AMI" : {
+      "us-east-1"      : { "PV64" : "ami-50842d38", "HVM64" : "ami-08842d60", "HVMG2" : "ami-3a329952"  },
+      "us-west-2"      : { "PV64" : "ami-af86c69f", "HVM64" : "ami-8786c6b7", "HVMG2" : "ami-47296a77"  },
+      "us-west-1"      : { "PV64" : "ami-c7a8a182", "HVM64" : "ami-cfa8a18a", "HVMG2" : "ami-331b1376"  },
+      "eu-west-1"      : { "PV64" : "ami-aa8f28dd", "HVM64" : "ami-748e2903", "HVMG2" : "ami-00913777"  },
+      "ap-southeast-1" : { "PV64" : "ami-20e1c572", "HVM64" : "ami-d6e1c584", "HVMG2" : "ami-fabe9aa8"  },
+      "ap-northeast-1" : { "PV64" : "ami-21072820", "HVM64" : "ami-35072834", "HVMG2" : "ami-5dd1ff5c"  },
+      "ap-southeast-2" : { "PV64" : "ami-8b4724b1", "HVM64" : "ami-fd4724c7", "HVMG2" : "ami-e98ae9d3"  },
+      "sa-east-1"      : { "PV64" : "ami-9d6cc680", "HVM64" : "ami-956cc688", "HVMG2" : "NOT_SUPPORTED" },
+      "cn-north-1"     : { "PV64" : "ami-a857c591", "HVM64" : "ami-ac57c595", "HVMG2" : "NOT_SUPPORTED" },
+      "eu-central-1"   : { "PV64" : "ami-a03503bd", "HVM64" : "ami-b43503a9", "HVMG2" : "ami-b03503ad"  }
+    }
 
-  <property>
-    <name>yarn.nodemanager.local-dirs</name>
-    <value>/mnt/yarn,/mnt1/yarn</value>
-    <final>true</final>
-  </property>
+  },
+    
+  "Resources" : {     
+      
+    "ZeppelinInstance": {  
+      "Type": "AWS::EC2::Instance",
+      "Metadata" : {
+        "AWS::CloudFormation::Interface" : {
+          "ParameterGroups" : [
+           {
+             "Label" : { "default" : "Network Configuration" },
+             "Parameters" : [ "ZeppelinVPCID", "ZeppelinSubnetId", "EMRMasterSecurityGroup", "EMRMasterSlaveGroup" ]
+            },
+          {
+             "Label" : { "default":"Amazon EC2 Configuration" },
+             "Parameters" : [ "InstanceType", "KeyName" ]
+            }
+            ],
+          "ParameterLabels" : {
+            "ZeppelinVPCID" : { "default" : "Which VPC should this be deployed to?" }
+              }
+          },
 
-  <property>
-    <description>Where to store container logs.</description>
-    <name>yarn.nodemanager.log-dirs</name>
-    <value>/var/log/hadoop-yarn/containers</value>
-  </property>
+        "AWS::CloudFormation::Init" : {
+          "configSets" : {
+            "InstallAndRun" : [ "Install", "Configure" ]
+          },
 
-  <property>
-    <description>Where to aggregate logs to.</description>
-    <name>yarn.nodemanager.remote-app-log-dir</name>
-    <value>/var/log/hadoop-yarn/apps</value>
-  </property>
+          "Install" : {
+            "packages" : {
+              "yum" : {
+                "git"          : [],
+                "java-1.7.0-openjdk-devel.x86_64": []
+              }
+            },
+             "sources": {
+							"/home/ec2-user/prereqs/": "http://d3kbcqa49mib13.cloudfront.net/spark-1.5.2-bin-hadoop2.6.tgz"
+							},
+              "commands" : {
+              "01-install-git" : {
+              "command" : "git clone https://github.com/apache/incubator-zeppelin /home/ec2-user/zeppelin",       
+              "ignoreErrors" : "true"
+                },
+              "02-maven-step1": {
+             "command" : "wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo",       
+              "ignoreErrors" : "true"
+                },
+             "03-maven-step2": {
+             "command" : "sed -i s/\\$releasever/6/g /etc/yum.repos.d/epel-apache-maven.repo",       
+              "ignoreErrors" : "true"
+                }, 
+                
+              "04-download_hadoopconf" : {
+              "command" : { "Fn::Join" : ["", ["aws s3 sync s3://", { "Ref" : "S3HadoopConfFolder" }, " ", "/home/ec2-user/hadoopconf"]]},
+              "ignoreErrors" : "true"                           
+              } 
+             },  
+            "files" : {
+              "/etc/cfn/cfn-hup.conf" : {
+                "content" : { "Fn::Join" : ["", [
+                  "[main]\n",
+                  "stack=", { "Ref" : "AWS::StackId" }, "\n",
+                  "region=", { "Ref" : "AWS::Region" }, "\n"
+                ]]},
+                "mode"    : "000400",
+                "owner"   : "root",
+                "group"   : "root"
+              },
 
-  <property>
-    <description>Classpath for typical applications.</description>
-     <name>yarn.application.classpath</name>
-     <value>
-        $HADOOP_CONF_DIR,
-        $HADOOP_COMMON_HOME/*,$HADOOP_COMMON_HOME/lib/*,
-        $HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,
-        $HADOOP_MAPRED_HOME/*,$HADOOP_MAPRED_HOME/lib/*,
-        $HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,
-        $HADOOP_MAPRED_HOME/*,$HADOOP_MAPRED_HOME/lib/*,
-        $HADOOP_YARN_HOME/*,$HADOOP_YARN_HOME/lib/*,
-        /usr/lib/hadoop-lzo/lib/*,
-        /usr/share/aws/emr/emrfs/conf,
-        /usr/share/aws/emr/emrfs/lib/*,
-        /usr/share/aws/emr/emrfs/auxlib/*,
-        /usr/share/aws/emr/lib/*,
-        /usr/share/aws/emr/ddb/lib/emr-ddb-hadoop.jar,
-        /usr/share/aws/emr/goodies/lib/emr-hadoop-goodies.jar,
-        /usr/share/aws/emr/kinesis/lib/emr-kinesis-hadoop.jar,
-        /usr/lib/spark/yarn/lib/datanucleus-api-jdo.jar,
-        /usr/lib/spark/yarn/lib/datanucleus-core.jar,
-        /usr/lib/spark/yarn/lib/datanucleus-rdbms.jar,
-        /usr/share/aws/emr/cloudwatch-sink/lib/*
-     </value>
-  </property>
+              "/etc/cfn/hooks.d/cfn-auto-reloader.conf" : {
+                "content": { "Fn::Join" : ["", [
+                  "[cfn-auto-reloader-hook]\n",
+                  "triggers=post.update\n",
+                  "path=Resources.ZeppelinInstance.Metadata.AWS::CloudFormation::Init\n",
+                  "action=/opt/aws/bin/cfn-init -v ",
+                  "         --stack ", { "Ref" : "AWS::StackName" },
+                  "         --resource ZeppelinInstance ",
+                  "         --configsets InstallAndRun ",
+                  "         --region ", { "Ref" : "AWS::Region" }, "\n",
+                  "runas=root\n"
+                ]]}
+              }
+            },
+           
+            "services" : {
+              "sysvinit" : {  
+                "cfn-hup" : { "enabled" : "true", "ensureRunning" : "true",
+                              "files" : ["/etc/cfn/cfn-hup.conf", "/etc/cfn/hooks.d/cfn-auto-reloader.conf"]}
+              }
+            }
+          },
 
-  <property>
-    <name>yarn.nodemanager.address</name>
-    <value>${yarn.nodemanager.hostname}:8041</value>
-  </property>
+          "Configure" : {
+             "packages" : {
+              "yum" : {
+                "apache-maven"          : []
+              }
+            },
+            
+            "files" : {
+            "/home/ec2-user/prereqs/spark-1.5.2-bin-hadoop2.6/conf/spark-env.sh": {
+            "source" : "https://github.com/awslabs/aws-big-data-blog/blob/master/aws-blog/zeppelin-yarn-on-ec2/conf/spark-env.sh",
+            "mode": "000644",
+            "owner" : "root",
+            "group" : "root"
+            },
+             "/home/ec2-user/zeppelin/conf/zeppelin-env.sh": {
+             "source" : "https://github.com/awslabs/aws-big-data-blog/blob/master/aws-blog/zeppelin-yarn-on-ec2/conf/zeppelin-env.sh",
+             "mode": "000644",
+            "owner" : "root",
+            "group" : "root"
+             },
+             "/home/ec2-user/zeppelin/conf/zeppelin-site.xml": {
+             "source" : "https://github.com/awslabs/aws-big-data-blog/blob/master/aws-blog/zeppelin-yarn-on-ec2/conf/zeppelin-site.xml",
+             "mode": "000644",
+            "owner" : "root",
+            "group" : "root"
+             }
+           },
 
-  <property>
-    <name>yarn.scheduler.increment-allocation-mb</name>
-    <value>32</value>
-  </property>
-
-  <property>
-    <name>yarn.resourcemanager.client.thread-count</name>
-    <value>64</value>
-  </property>
-
-  <property>
-    <name>yarn.nodemanager.resource.cpu-vcores</name>
-    <value>8</value>
-  </property>
-
-  <property>
-    <name>yarn.resourcemanager.resource-tracker.client.thread-count</name>
-    <value>64</value>
-  </property>
-
-  <property>
-    <name>yarn.nodemanager.container-manager.thread-count</name>
-    <value>64</value>
-   <name>yarn.nodemanager.container-manager.thread-count</name>
-    <value>64</value>
-  </property>
-
-  <property>
-    <name>yarn.resourcemanager.scheduler.client.thread-count</name>
-    <value>64</value>
-  </property>
-
-  <property>
-    <name>yarn.scheduler.maximum-allocation-mb</name>
-    <value>11520</value>
-  </property>
-
-  <property>
-    <name>yarn.nodemanager.localizer.client.thread-count</name>
-    <value>20</value>
-  </property>
-
-  <property>
-    <name>yarn.nodemanager.localizer.fetch.thread-count</name>
-    <value>20</value>
-  </property>
-
-  <property>
-    <name>yarn.nodemanager.resource.memory-mb</name>
-    <value>11520</value>
-  </property>
-
-  <property>
-    <name>yarn.nodemanager.vmem-pmem-ratio</name>
-    <value>5</value>
-  </property>
-
-  <property>
-    <name>yarn.resourcemanager.hostname</name>
-    <value>172.31.29.88</value>
-  </property>
-
-  <property>
-    <name>yarn.scheduler.minimum-allocation-mb</name>
-    <value>256</value>
-  </property>
-
-  <property>
-    <name>yarn.label.enabled</name>
-  <property>
-    <name>yarn.label.enabled</name>
-    <value>true</value>
-  </property>
-
-  <property>
-    <name>yarn.app.mapreduce.am.labels</name>
-    <value>CORE</value>
-  </property>
+            "commands" : {
+              "01_change_owner_zeppelin" : {
+              "command" : "chown -R ec2-user /home/ec2-user/zeppelin",       
+              "ignoreErrors" : "true"
+              },
+              "02_build_zeppelin" : {
+              "command" : "cd /home/ec2-user/zeppelin; mvn clean package -Pspark-1.5 -Dspark.version=1.5.2 -Phadoop-2.6 -Pyarn -DskipTests",       
+              "ignoreErrors" : "true"
+              }
+            }
+          }
+        }
+      },
+      "Properties": {
+        "ImageId" : { "Fn::FindInMap" : [ "AWSRegionArch2AMI", { "Ref" : "AWS::Region" },
+                          { "Fn::FindInMap" : [ "AWSInstanceType2Arch", { "Ref" : "InstanceType" }, "Arch" ] } ] },
+        "InstanceType"   : { "Ref" : "InstanceType" },
+        "KeyName"        : { "Ref" : "KeyName" },
+        "NetworkInterfaces" : [{
+          "GroupSet"                 : [{ "Ref" : "ZeppelinSecurityGroup" }],
+          "AssociatePublicIpAddress" : "true",
+          "DeviceIndex"              : "0",
+          "DeleteOnTermination"      : "true",
+          "SubnetId"                 : { "Ref" : "ZeppelinSubnetId" }
+        }],
+        "IamInstanceProfile": {
+               "Ref": "MyInstanceProfile"
+            },
+        "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
+             "#!/bin/bash -xe\n",
+             "yum update -y aws-cfn-bootstrap\n",
+             "echo 'export JAVA_HOME=/etc/alternatives/java_sdk' >> /home/ec2-user/.bash_profile\n",
+             "echo 'export PATH=$PATH:$JAVA_HOME/bin' >> /home/ec2-user/.bash_profile\n",
+             "# Install the files and packages from the metadata\n",
+             "/opt/aws/bin/cfn-init -v ",
+             "         --stack ", { "Ref" : "AWS::StackName" },
+             "         --resource ZeppelinInstance ",
+             "         --configsets InstallAndRun ",
+             "         --region ", { "Ref" : "AWS::Region" }, "\n",
+             "# Signal the status from cfn-init\n",
+             "/opt/aws/bin/cfn-signal -e $? ",
+             "         --stack ", { "Ref" : "AWS::StackName" },
+             "         --resource ZeppelinInstance ",
+             "         --region ", { "Ref" : "AWS::Region" }, "\n"
+        ]]}}        
+      },
+      "CreationPolicy" : {
+        "ResourceSignal" : {
+          "Timeout" : "PT30M"
+        }
+      }
+    },
+      "MyRole": {
+         "Type": "AWS::IAM::Role",
+         "Properties": {
+            "AssumeRolePolicyDocument": {
+               "Version" : "2012-10-17",
+               "Statement": [ {
+                  "Effect": "Allow",
+                  "Principal": {
+                     "Service": [ "ec2.amazonaws.com" ]
+                  },
+                  "Action": [ "sts:AssumeRole" ]
+               } ]
+            },
+            "Path": "/"
+         }
+      },
+      "RolePolicies": {
+         "Type": "AWS::IAM::Policy",
+         "Properties": {
+            "PolicyName": "s3access",
+            "PolicyDocument": {
+               "Version" : "2012-10-17",
+               "Statement": [ {
+                  "Effect": "Allow",
+                  "Action": "s3:*",
+                  "Resource": "*"
+               } ]
+            },
+            "Roles": [ { "Ref": "MyRole" } ]
+         }
+      },
+      "MyInstanceProfile": {
+         "Type": "AWS::IAM::InstanceProfile",
+         "Properties": {
+            "Path": "/",
+            "Roles": [ { "Ref": "MyRole" } ]
+         }
+      },    
+    "ZeppelinSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable access to Zeppelin over port 8080, access to EMR cluster through EMRMaster and EMRSlave Security Groups",
+        "VpcId" : { "Ref" : "ZeppelinVPCId" },
+        "SecurityGroupIngress" : [
+          {"IpProtocol" : "tcp", "FromPort" : "8080", "ToPort" : "8080", "CidrIp" : "0.0.0.0/0"},
+          {"IpProtocol" : "tcp", "FromPort" : "0", "ToPort" : "65535", "SourceSecurityGroupId" : { "Ref" : "EMRMasterSecurityGroup"}},
+          {"IpProtocol" : "tcp", "FromPort" : "0", "ToPort" : "65535", "SourceSecurityGroupId" : { "Ref" : "EMRSlaveSecurityGroup"}},
+          {"IpProtocol" : "tcp", "FromPort" : "22", "ToPort" : "22", "CidrIp" : { "Ref" : "SSHLocation"}}
+        ]
+      }      
+    }          
+  },
+  
+  "Outputs" : {
+    "WebsiteURL" : {
+      "Description" : "URL for newly created Zeppelin stack",
+      "Value" : { "Fn::Join" : ["", ["http://", { "Fn::GetAtt" : [ "ZeppelinInstance", "PublicDnsName"]},":8080"]] }
+    }
+  }
+}
 
   <property>
     <name>yarn.nodemanager.labels</name>

--- a/aws-blog-zeppelin-yarn-on-ec2/zeppelin-yarn-on-ec2.json
+++ b/aws-blog-zeppelin-yarn-on-ec2/zeppelin-yarn-on-ec2.json
@@ -142,7 +142,7 @@
               }
             },
              "sources": {
-							"/home/ec2-user/prereqs/": "http://d3kbcqa49mib13.cloudfront.net/spark-1.5.2-bin-hadoop2.6.tgz"
+							"/home/ec2-user/prereqs/": "http://aws-bigdata-blog.s3.amazonaws.com/artifacts/spark-1.5.2-bin-hadoop2.6.tgz"
 							},
               "commands" : {
               "01-install-git" : {

--- a/aws-blog-zeppelin-yarn-on-ec2/zeppelin-yarn-on-ec2.json
+++ b/aws-blog-zeppelin-yarn-on-ec2/zeppelin-yarn-on-ec2.json
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+<property><name>yarn.web-proxy.address</name><value>ip-172-31-29-88.us-west-1.compute.internal:20888</value></property>
+<property><name>yarn.resourcemanager.resource-tracker.address</name><value>ip-172-31-29-88.us-west-1.compute.internal:8025</value></property>
+<property><name>yarn.resourcemanager.address</name><value>ip-172-31-29-88.us-west-1.compute.internal:8032</value></property>
+<property><name>yarn.resourcemanager.scheduler.address</name><value>ip-172-31-29-88.us-west-1.compute.internal:8030</value></property>
+<property><name>yarn.nodemanager.aux-services</name>
+<property>
+    <name>yarn.nodemanager.aux-services</name>
+    <value>mapreduce_shuffle,</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
+    <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+  </property>
+
+  <property><name>yarn.log-aggregation-enable</name><value>false</value></property>
+
+  <property>
+    <name>yarn.dispatcher.exit-on-error</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.local-dirs</name>
+    <value>/mnt/yarn,/mnt1/yarn</value>
+    <final>true</final>
+  </property>
+
+  <property>
+    <description>Where to store container logs.</description>
+    <name>yarn.nodemanager.log-dirs</name>
+    <value>/var/log/hadoop-yarn/containers</value>
+  </property>
+
+  <property>
+    <description>Where to aggregate logs to.</description>
+    <name>yarn.nodemanager.remote-app-log-dir</name>
+    <value>/var/log/hadoop-yarn/apps</value>
+  </property>
+
+  <property>
+    <description>Classpath for typical applications.</description>
+     <name>yarn.application.classpath</name>
+     <value>
+        $HADOOP_CONF_DIR,
+        $HADOOP_COMMON_HOME/*,$HADOOP_COMMON_HOME/lib/*,
+        $HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,
+        $HADOOP_MAPRED_HOME/*,$HADOOP_MAPRED_HOME/lib/*,
+        $HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,
+        $HADOOP_MAPRED_HOME/*,$HADOOP_MAPRED_HOME/lib/*,
+        $HADOOP_YARN_HOME/*,$HADOOP_YARN_HOME/lib/*,
+        /usr/lib/hadoop-lzo/lib/*,
+        /usr/share/aws/emr/emrfs/conf,
+        /usr/share/aws/emr/emrfs/lib/*,
+        /usr/share/aws/emr/emrfs/auxlib/*,
+        /usr/share/aws/emr/lib/*,
+        /usr/share/aws/emr/ddb/lib/emr-ddb-hadoop.jar,
+        /usr/share/aws/emr/goodies/lib/emr-hadoop-goodies.jar,
+        /usr/share/aws/emr/kinesis/lib/emr-kinesis-hadoop.jar,
+        /usr/lib/spark/yarn/lib/datanucleus-api-jdo.jar,
+        /usr/lib/spark/yarn/lib/datanucleus-core.jar,
+        /usr/lib/spark/yarn/lib/datanucleus-rdbms.jar,
+        /usr/share/aws/emr/cloudwatch-sink/lib/*
+     </value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.address</name>
+    <value>${yarn.nodemanager.hostname}:8041</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.increment-allocation-mb</name>
+    <value>32</value>
+  </property>
+
+  <property>
+    <name>yarn.resourcemanager.client.thread-count</name>
+    <value>64</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.resource.cpu-vcores</name>
+    <value>8</value>
+  </property>
+
+  <property>
+    <name>yarn.resourcemanager.resource-tracker.client.thread-count</name>
+    <value>64</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.container-manager.thread-count</name>
+    <value>64</value>
+   <name>yarn.nodemanager.container-manager.thread-count</name>
+    <value>64</value>
+  </property>
+
+  <property>
+    <name>yarn.resourcemanager.scheduler.client.thread-count</name>
+    <value>64</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.maximum-allocation-mb</name>
+    <value>11520</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.localizer.client.thread-count</name>
+    <value>20</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.localizer.fetch.thread-count</name>
+    <value>20</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.resource.memory-mb</name>
+    <value>11520</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.vmem-pmem-ratio</name>
+    <value>5</value>
+  </property>
+
+  <property>
+    <name>yarn.resourcemanager.hostname</name>
+    <value>172.31.29.88</value>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.minimum-allocation-mb</name>
+    <value>256</value>
+  </property>
+
+  <property>
+    <name>yarn.label.enabled</name>
+  <property>
+    <name>yarn.label.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>yarn.app.mapreduce.am.labels</name>
+    <value>CORE</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.labels</name>
+    <value>MASTER</value>
+  </property>
+</configuration>
+


### PR DESCRIPTION
committed artifacts
zeppelin-yarn-on-ec2.json -- Cloudformation template the provisions EC2 instance with Zeppelin
README.md                     -- Readme explaining repo
../conf/spark-env.sh           -- Cloudformation places this file in EC2 <SPARK_HOME>/conf directory
../conf/zeppelin-env.sh      -- Cloudformation places this file in EC2 <ZEPPELIN_HOME>/conf directory
../conf/zeppelin-env.sh      -- Cloudformation places this file in EC2 <ZEPPELIN_HOME>/conf directory

