### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/aws-blog-real-time-clickstream/CSE-cfn.json
+++ b/aws-blog-real-time-clickstream/CSE-cfn.json
@@ -271,7 +271,7 @@
         "Handler" : "index.handler",
         "MemorySize" : 128,
         "Role" :  { "Fn::GetAtt" : [ "LambdaExecutionRole", "Arn" ] } ,
-        "Runtime" : "nodejs4.3",
+        "Runtime" : "nodejs10.x",
         "Timeout" : 5
       }
     },


### PR DESCRIPTION
CloudFormation templates in aws-big-data-blog have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.